### PR TITLE
Transfer metadata examples

### DIFF
--- a/content/examples/debian.md
+++ b/content/examples/debian.md
@@ -1,0 +1,434 @@
+---
+title: debian example metadata
+---
+
+## Layout
+
+### debian/root.layout
+``` json
+{
+  "signed": {
+    "_type": "layout",
+    "readme": "",
+    "expires": "2017-09-02T12:57:02Z",
+    "steps": [
+      {
+        "_type": "step",
+        "name": "fetch",
+        "expected_command": [
+          "dget",
+          "http://cdn.debian.net/debian/pool/main/g/grep/grep_2.12-2.dsc"
+        ],
+        "pubkeys": [
+          "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "DISALLOW",
+            "*"
+          ]
+        ],
+        "expected_products": [
+          [
+            "ALLOW",
+            "*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "extract",
+        "expected_command": [
+          "dpkg-source",
+          "-x",
+          "grep_2.12-2.dsc"
+        ],
+        "pubkeys": [
+          "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "fetch"
+          ]
+        ],
+        "expected_products": [
+          [
+            "ALLOW",
+            "*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "modify",
+        "expected_command": [],
+        "pubkeys": [
+          "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "extract"
+          ]
+        ],
+        "expected_products": [
+          [
+            "ALLOW",
+            "*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "build",
+        "expected_command": [
+          "dpkg-buildpackage",
+          "-us",
+          "-uc"
+        ],
+        "pubkeys": [
+          "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "modify"
+          ]
+        ],
+        "expected_products": [
+          [
+            "ALLOW",
+            "*"
+          ]
+        ]
+      }
+    ],
+    "inspect": [],
+    "keys": {
+      "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2": {
+        "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+        "keytype": "rsa",
+        "keyval": {
+          "private": "",
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKC..."
+        }
+      }
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+      "method": "RSASSA-PSS",
+      "sig": "9c3a5609e79ea68f9d7aa4b72e5ab1f00b7773f06912b789add45da026f46621b9e..."
+    }
+  ]
+}
+
+```
+
+
+## Links
+
+### debian/fetch.12c55e46.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "fetch",
+    "command": [
+      "dget",
+      "http://cdn.debian.net/debian/pool/main/g/grep/grep_2.12-2.dsc"
+    ],
+    "materials": {},
+    "products": {
+      "/home/lukas/demo/grep_2.12-2.debian.tar.bz2": {
+        "sha256": "37887d8aecec66e75365abd8c41be94f75e7a3acf1d6b27fc121584f47281525"
+      },
+      "/home/lukas/demo/grep_2.12-2.dsc": {
+        "sha256": "a6a63fd21da40d11ce6ae2bc6f633bd27cd206c2348b2ef306e1b68120f7e58e"
+      },
+      "/home/lukas/demo/grep_2.12.orig.tar.bz2": {
+        "sha256": "0119987171cd60b87c89557524fc6636bdad770dae71917adcaef6abffb1be67"
+      }
+    },
+    "byproducts": {
+      "return_value": 1,
+      "stdout": "dget: retrieving http://cdn.debian.net/debian/pool/main/g/grep/grep...",
+      "stderr": "--2017-08-08 11:05:06--  http://cdn.debian.net/debian/pool/main/g/g..."
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+      "method": "RSASSA-PSS",
+      "sig": "a0d3237a59a96343b2e2caee2bf0e27a249a01f796c3fec53f184fc2720b44dd7b2..."
+    }
+  ]
+}
+
+```
+
+
+### debian/extract.12c55e46.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "extract",
+    "command": [
+      "dpkg-source",
+      "-x",
+      "grep_2.12-2.dsc"
+    ],
+    "materials": {
+      "/home/lukas/demo/grep_2.12-2.debian.tar.bz2": {
+        "sha256": "37887d8aecec66e75365abd8c41be94f75e7a3acf1d6b27fc121584f47281525"
+      },
+      "/home/lukas/demo/grep_2.12-2.dsc": {
+        "sha256": "a6a63fd21da40d11ce6ae2bc6f633bd27cd206c2348b2ef306e1b68120f7e58e"
+      },
+      "/home/lukas/demo/grep_2.12.orig.tar.bz2": {
+        "sha256": "0119987171cd60b87c89557524fc6636bdad770dae71917adcaef6abffb1be67"
+      }
+    },
+    "products": {
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_patches": {
+        "sha256": "0623de532bc23399e87e6c1914e8e90e999efbfd26b6b956666a493893739f0d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_series": {
+        "sha256": "9afbb183d1b683d2770aecb9b379093804ccc56027f07ecf7fc252d5b93a8df2"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.version": {
+        "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/02-man_rgrep.patch/doc/grep.in.1": {
+        "sha256": "0c933cbdacb739761f7cf9be1d9c0543b8a5cb0c1cf4031fc7add8e81146c1a6"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/configure": {
+        "sha256": "fda1f6c62f081999b74177f560e14db0b0b2f93cd632ed4a02f6ac2582fc27bf"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/src/pcresearch.c": {
+        "sha256": "08e24565e42cf5e2aeff2ca65cc4e3a8de5fa65260ea1a2d1ae872b45c3b6a25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/04-446854-grep.1.patch/doc/grep.in.1": {
+        "sha256": "90b74e6c5542b0db506c372f77c45ceab8d7289432cfe37bce11d611a4827a4d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/70-man_apostrophe.patch/doc/grep.in.1": {
+        "sha256": "eee01bf4de92df307b7f1b6fa740e1c0e0c8c28d6a12b6939ddec0708699da25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/80-587930-man-ere-reference.patch/doc/grep.in.1": {
+        "sha256": "30378876bf1c1a13449c993fb7a6406089f7f77a34f96fed5c6c742e75a395b6"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "dpkg-source: info: extracting grep in grep-2.12\ndpkg-source: info: ...",
+      "stderr": "gpgv: Signature made Sun 13 May 2012 08:23:12 AM EDT using DSA key ..."
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+      "method": "RSASSA-PSS",
+      "sig": "9b89cf0a74a1d53359460982cdc3dcbdef2b291a284b977fadb839501d7324fe581..."
+    }
+  ]
+}
+
+```
+
+
+### debian/modify.12c55e46.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "modify",
+    "command": [],
+    "materials": {
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_patches": {
+        "sha256": "0623de532bc23399e87e6c1914e8e90e999efbfd26b6b956666a493893739f0d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_series": {
+        "sha256": "9afbb183d1b683d2770aecb9b379093804ccc56027f07ecf7fc252d5b93a8df2"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.version": {
+        "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/02-man_rgrep.patch/doc/grep.in.1": {
+        "sha256": "0c933cbdacb739761f7cf9be1d9c0543b8a5cb0c1cf4031fc7add8e81146c1a6"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/configure": {
+        "sha256": "fda1f6c62f081999b74177f560e14db0b0b2f93cd632ed4a02f6ac2582fc27bf"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/src/pcresearch.c": {
+        "sha256": "08e24565e42cf5e2aeff2ca65cc4e3a8de5fa65260ea1a2d1ae872b45c3b6a25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/04-446854-grep.1.patch/doc/grep.in.1": {
+        "sha256": "90b74e6c5542b0db506c372f77c45ceab8d7289432cfe37bce11d611a4827a4d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/70-man_apostrophe.patch/doc/grep.in.1": {
+        "sha256": "eee01bf4de92df307b7f1b6fa740e1c0e0c8c28d6a12b6939ddec0708699da25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/80-587930-man-ere-reference.patch/doc/grep.in.1": {
+        "sha256": "30378876bf1c1a13449c993fb7a6406089f7f77a34f96fed5c6c742e75a395b6"
+      },
+      "...": "..."
+    },
+    "products": {
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_patches": {
+        "sha256": "0623de532bc23399e87e6c1914e8e90e999efbfd26b6b956666a493893739f0d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_series": {
+        "sha256": "9afbb183d1b683d2770aecb9b379093804ccc56027f07ecf7fc252d5b93a8df2"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.version": {
+        "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/02-man_rgrep.patch/doc/grep.in.1": {
+        "sha256": "0c933cbdacb739761f7cf9be1d9c0543b8a5cb0c1cf4031fc7add8e81146c1a6"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/configure": {
+        "sha256": "fda1f6c62f081999b74177f560e14db0b0b2f93cd632ed4a02f6ac2582fc27bf"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/src/pcresearch.c": {
+        "sha256": "08e24565e42cf5e2aeff2ca65cc4e3a8de5fa65260ea1a2d1ae872b45c3b6a25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/04-446854-grep.1.patch/doc/grep.in.1": {
+        "sha256": "90b74e6c5542b0db506c372f77c45ceab8d7289432cfe37bce11d611a4827a4d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/70-man_apostrophe.patch/doc/grep.in.1": {
+        "sha256": "eee01bf4de92df307b7f1b6fa740e1c0e0c8c28d6a12b6939ddec0708699da25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/80-587930-man-ere-reference.patch/doc/grep.in.1": {
+        "sha256": "30378876bf1c1a13449c993fb7a6406089f7f77a34f96fed5c6c742e75a395b6"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": null
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+      "method": "RSASSA-PSS",
+      "sig": "6c922765260c71bbe0eef0267c2ad6f226eeec43ef45b5dcba6314f52adba655265..."
+    }
+  ]
+}
+
+```
+
+
+### debian/build.12c55e46.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "build",
+    "command": [
+      "dpkg-buildpackage",
+      "-us",
+      "-uc"
+    ],
+    "materials": {
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_patches": {
+        "sha256": "0623de532bc23399e87e6c1914e8e90e999efbfd26b6b956666a493893739f0d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_series": {
+        "sha256": "9afbb183d1b683d2770aecb9b379093804ccc56027f07ecf7fc252d5b93a8df2"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.version": {
+        "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/02-man_rgrep.patch/doc/grep.in.1": {
+        "sha256": "0c933cbdacb739761f7cf9be1d9c0543b8a5cb0c1cf4031fc7add8e81146c1a6"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/configure": {
+        "sha256": "fda1f6c62f081999b74177f560e14db0b0b2f93cd632ed4a02f6ac2582fc27bf"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/src/pcresearch.c": {
+        "sha256": "08e24565e42cf5e2aeff2ca65cc4e3a8de5fa65260ea1a2d1ae872b45c3b6a25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/04-446854-grep.1.patch/doc/grep.in.1": {
+        "sha256": "90b74e6c5542b0db506c372f77c45ceab8d7289432cfe37bce11d611a4827a4d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/70-man_apostrophe.patch/doc/grep.in.1": {
+        "sha256": "eee01bf4de92df307b7f1b6fa740e1c0e0c8c28d6a12b6939ddec0708699da25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/80-587930-man-ere-reference.patch/doc/grep.in.1": {
+        "sha256": "30378876bf1c1a13449c993fb7a6406089f7f77a34f96fed5c6c742e75a395b6"
+      },
+      "...": "..."
+    },
+    "products": {
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_patches": {
+        "sha256": "0623de532bc23399e87e6c1914e8e90e999efbfd26b6b956666a493893739f0d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.quilt_series": {
+        "sha256": "9afbb183d1b683d2770aecb9b379093804ccc56027f07ecf7fc252d5b93a8df2"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/.version": {
+        "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/02-man_rgrep.patch/doc/grep.in.1": {
+        "sha256": "0c933cbdacb739761f7cf9be1d9c0543b8a5cb0c1cf4031fc7add8e81146c1a6"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/configure": {
+        "sha256": "fda1f6c62f081999b74177f560e14db0b0b2f93cd632ed4a02f6ac2582fc27bf"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/03-397262-dlopen-pcre.patch/src/pcresearch.c": {
+        "sha256": "08e24565e42cf5e2aeff2ca65cc4e3a8de5fa65260ea1a2d1ae872b45c3b6a25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/04-446854-grep.1.patch/doc/grep.in.1": {
+        "sha256": "90b74e6c5542b0db506c372f77c45ceab8d7289432cfe37bce11d611a4827a4d"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/70-man_apostrophe.patch/doc/grep.in.1": {
+        "sha256": "eee01bf4de92df307b7f1b6fa740e1c0e0c8c28d6a12b6939ddec0708699da25"
+      },
+      "/home/lukas/demo/grep-2.12/.pc/80-587930-man-ere-reference.patch/doc/grep.in.1": {
+        "sha256": "30378876bf1c1a13449c993fb7a6406089f7f77a34f96fed5c6c742e75a395b6"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "dpkg-buildpackage: source package grep\ndpkg-buildpackage: source ve...",
+      "stderr": " dpkg-source --before-build grep-2.12\n fakeroot debian/rules clean\n..."
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "12c55e46654c682d3ffd3b63492adf422e6812eb1ac41574d083b9e770d1e4c2",
+      "method": "RSASSA-PSS",
+      "sig": "3877a06dee3f6e140e20d5100964adb38c1c63dd89803087204d561c0adbfed17c2..."
+    }
+  ]
+}
+
+```
+
+

--- a/content/examples/polypasswordhasher.md
+++ b/content/examples/polypasswordhasher.md
@@ -1,0 +1,510 @@
+---
+title: polypasswordhasher example metadata
+---
+
+## Layout
+
+### polypasswordhasher/root.layout
+``` json
+{
+  "signed": {
+    "_type": "layout",
+    "readme": "",
+    "expires": "2016-12-10T13:09:03Z",
+    "steps": [
+      {
+        "_type": "step",
+        "name": "tag-release",
+        "expected_command": [
+          "git",
+          "tag"
+        ],
+        "pubkeys": [
+          "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f"
+        ],
+        "threshold": 1,
+        "expected_materials": [],
+        "expected_products": [
+          [
+            "CREATE",
+            "polypasswordhasher/*.py"
+          ],
+          [
+            "CREATE",
+            "setup.py"
+          ],
+          [
+            "CREATE",
+            "test/test*.py"
+          ],
+          [
+            "CREATE",
+            "test/__init__.py"
+          ],
+          [
+            "CREATE",
+            "test/runtests.py"
+          ],
+          [
+            "CREATE",
+            "src/fastpolymath.c"
+          ],
+          [
+            "CREATE",
+            "include/fastpolymath.h"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "build-sdist",
+        "expected_command": [
+          "python",
+          "setup.py",
+          "sdist"
+        ],
+        "pubkeys": [
+          "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "polypasswordhasher/*.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "src/fastpolymath.c",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "include/fastpolymath.h",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "setup.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/test*.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/__init__.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/runtests.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "dist/PolyPasswordHasher-0.2a0.tar.gz"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "test",
+        "expected_command": [
+          "python",
+          "setup.py",
+          "test"
+        ],
+        "pubkeys": [
+          "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "polypasswordhasher/*.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "src/fastpolymath.c",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "include/fastpolymath.h",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/test*.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/__init__*.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test/runtests.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "setup.py",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ]
+        ],
+        "expected_products": []
+      }
+    ],
+    "inspect": [
+      {
+        "_type": "inspection",
+        "name": "untar",
+        "run": [
+          "tar",
+          "xvf",
+          "PolyPasswordHasher-0.2a0.tar.gz"
+        ],
+        "expected_materials": [
+          [
+            "MATCH",
+            "PolyPasswordHasher-0.2a0.tar.gz",
+            "WITH",
+            "PRODUCTS",
+            "IN",
+            "dist",
+            "FROM",
+            "build-sdist"
+          ],
+          [
+            "CREATE",
+            "*"
+          ]
+        ],
+        "expected_products": [
+          [
+            "MATCH",
+            "*.py",
+            "IN",
+            "PolyPasswordHasher-0.2a0/polypasswordhasher",
+            "WITH",
+            "PRODUCTS",
+            "IN",
+            "polypasswordhasher",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "fastpolymath.c",
+            "IN",
+            "PolyPasswordHasher-0.2a0/src",
+            "WITH",
+            "PRODUCTS",
+            "IN",
+            "src",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "fastpolymath.h",
+            "IN",
+            "PolyPasswordHasher-0.2a0/include",
+            "WITH",
+            "PRODUCTS",
+            "IN",
+            "include",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "test*.py",
+            "IN",
+            "PolyPasswordHasher-0.2a0/test",
+            "WITH",
+            "PRODUCTS",
+            "IN",
+            "test",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "MATCH",
+            "setup.py",
+            "IN",
+            "PolyPasswordHasher-0.2a0",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "tag-release"
+          ],
+          [
+            "CREATE",
+            "*"
+          ]
+        ]
+      }
+    ],
+    "keys": {
+      "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f": {
+        "keyid": "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f",
+        "keytype": "rsa",
+        "keyval": {
+          "private": "",
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKC..."
+        }
+      }
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "ee4ca725ae71eb8be7971505a301f6c6b9d1b0b25ccbf18b1532e7171b9741b5",
+      "method": "RSASSA-PSS",
+      "sig": "90119b3329753ed3cf58e20071c99cf68e4eb56dcecd98bb409da4ff7ce3e1351d7..."
+    }
+  ]
+}
+
+```
+
+
+## Links
+
+### polypasswordhasher/tag-release.xxx.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "tag-release",
+    "command": [
+      "git",
+      "tag",
+      "v0.2a"
+    ],
+    "materials": {},
+    "products": {
+      "include/fastpolymath.h": {
+        "sha256": "5be4945cdd1b958d3e8029c7b76333311485c2ccbc3e81ff64bfeb4e7a6fb5be"
+      },
+      "polypasswordhasher/__init__.py": {
+        "sha256": "a7464a8ee4ba930a554ff6cd87b3aad5b6328eda4732c5af55eb154e50569ac2"
+      },
+      "polypasswordhasher/fastshamirsecret.py": {
+        "sha256": "5b46ebba43be20ed20ea271b12c78e1b0fa8d53dbea8a53d48074977fe9b97cc"
+      },
+      "polypasswordhasher/polypasswordhasher.py": {
+        "sha256": "79b33112d045e244e8748b4e630aab3256ab664fc0dcc2cdc3262e847e180e13"
+      },
+      "polypasswordhasher/shamirsecret.py": {
+        "sha256": "cbc6d7dd59c65044300faadf1ce696469f8509622b35824643b1f35f5f8435fb"
+      },
+      "setup.py": {
+        "sha256": "f407ce7094ea452a3df6bd9cb8190fcd7c6e79e73593387cc84c70b94592f3d0"
+      },
+      "src/fastpolymath.c": {
+        "sha256": "79e0f36bf1e30460d0492e3f8bf1af4f40aabc54cddf47d68b6b28d124449a0f"
+      },
+      "test/__init__.py": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "test/runtests.py": {
+        "sha256": "fc65bc6775a866c687e9d7dc6d5c5f0bb4f9ef2ab658d34287a99e86fd13acf2"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f",
+      "method": "RSASSA-PSS",
+      "sig": "1edb549421d6ad62751b166f52b9868eded6680936b47a1d9907e904be7befce4b3..."
+    }
+  ]
+}
+
+```
+
+
+### polypasswordhasher/build-sdist.xxx.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "build-sdist",
+    "command": [
+      "python",
+      "setup.py",
+      "sdist"
+    ],
+    "materials": {
+      "include/fastpolymath.h": {
+        "sha256": "5be4945cdd1b958d3e8029c7b76333311485c2ccbc3e81ff64bfeb4e7a6fb5be"
+      },
+      "polypasswordhasher/__init__.py": {
+        "sha256": "a7464a8ee4ba930a554ff6cd87b3aad5b6328eda4732c5af55eb154e50569ac2"
+      },
+      "polypasswordhasher/fastshamirsecret.py": {
+        "sha256": "5b46ebba43be20ed20ea271b12c78e1b0fa8d53dbea8a53d48074977fe9b97cc"
+      },
+      "polypasswordhasher/polypasswordhasher.py": {
+        "sha256": "79b33112d045e244e8748b4e630aab3256ab664fc0dcc2cdc3262e847e180e13"
+      },
+      "polypasswordhasher/shamirsecret.py": {
+        "sha256": "cbc6d7dd59c65044300faadf1ce696469f8509622b35824643b1f35f5f8435fb"
+      },
+      "setup.py": {
+        "sha256": "f407ce7094ea452a3df6bd9cb8190fcd7c6e79e73593387cc84c70b94592f3d0"
+      },
+      "src/fastpolymath.c": {
+        "sha256": "79e0f36bf1e30460d0492e3f8bf1af4f40aabc54cddf47d68b6b28d124449a0f"
+      },
+      "test/__init__.py": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "test/runtests.py": {
+        "sha256": "fc65bc6775a866c687e9d7dc6d5c5f0bb4f9ef2ab658d34287a99e86fd13acf2"
+      },
+      "...": "..."
+    },
+    "products": {
+      "dist/PolyPasswordHasher-0.2a0.tar.gz": {
+        "sha256": "3620c4cab08f973431c048ec958dd76a9f6c2baa4cefdb85227856e2de100075"
+      }
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f",
+      "method": "RSASSA-PSS",
+      "sig": "a73e47fd3a9c7775431313c14c6e5d27a0d1e0e2396c0fd8b41bf0b7232d4f75c8e..."
+    }
+  ]
+}
+
+```
+
+
+### polypasswordhasher/test.xxx.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "test",
+    "command": [
+      "python",
+      "setup.py",
+      "test"
+    ],
+    "materials": {
+      "include/fastpolymath.h": {
+        "sha256": "5be4945cdd1b958d3e8029c7b76333311485c2ccbc3e81ff64bfeb4e7a6fb5be"
+      },
+      "polypasswordhasher/__init__.py": {
+        "sha256": "a7464a8ee4ba930a554ff6cd87b3aad5b6328eda4732c5af55eb154e50569ac2"
+      },
+      "polypasswordhasher/fastshamirsecret.py": {
+        "sha256": "5b46ebba43be20ed20ea271b12c78e1b0fa8d53dbea8a53d48074977fe9b97cc"
+      },
+      "polypasswordhasher/polypasswordhasher.py": {
+        "sha256": "79b33112d045e244e8748b4e630aab3256ab664fc0dcc2cdc3262e847e180e13"
+      },
+      "polypasswordhasher/shamirsecret.py": {
+        "sha256": "cbc6d7dd59c65044300faadf1ce696469f8509622b35824643b1f35f5f8435fb"
+      },
+      "setup.py": {
+        "sha256": "f407ce7094ea452a3df6bd9cb8190fcd7c6e79e73593387cc84c70b94592f3d0"
+      },
+      "src/fastpolymath.c": {
+        "sha256": "79e0f36bf1e30460d0492e3f8bf1af4f40aabc54cddf47d68b6b28d124449a0f"
+      },
+      "test/__init__.py": {
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "test/runtests.py": {
+        "sha256": "fc65bc6775a866c687e9d7dc6d5c5f0bb4f9ef2ab658d34287a99e86fd13acf2"
+      },
+      "...": "..."
+    },
+    "products": {},
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "48c92a75036a01a864a3a5546fddb601733e135692718afd3f896935474ffb7f",
+      "method": "RSASSA-PSS",
+      "sig": "80977ff9bc0265724ceb952ad99c2c35206e4ad4364d843e2b9d8e79057e70515c1..."
+    }
+  ]
+}
+
+```
+
+

--- a/content/examples/seattle.md
+++ b/content/examples/seattle.md
@@ -1,0 +1,593 @@
+---
+title: seattle example metadata
+---
+
+## Layout
+
+### seattle/root.layout
+``` json
+{
+  "signed": {
+    "_type": "layout",
+    "readme": "",
+    "expires": "2017-01-23T13:27:57Z",
+    "steps": [
+      {
+        "_type": "step",
+        "name": "clone-dependencies",
+        "expected_command": [
+          "python",
+          "initialize.py"
+        ],
+        "pubkeys": [
+          "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5"
+        ],
+        "threshold": 1,
+        "expected_materials": [],
+        "expected_products": [
+          [
+            "CREATE",
+            "installer-packaging/*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "build-runnable",
+        "expected_command": [
+          "python",
+          "build.py"
+        ],
+        "pubkeys": [
+          "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "installer-packaging/*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "clone-dependencies"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "installer-packaging/*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "pre-build-file-edit",
+        "expected_command": [
+          "edit",
+          "files",
+          "manually"
+        ],
+        "pubkeys": [
+          "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "installer-packaging/RUNNABLE/*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "build-runnable"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "installer-packaging/*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "build-base-installers",
+        "expected_command": [
+          "python",
+          "rebuild_base_installers.py",
+          "0.1-in-toto-in-seattle"
+        ],
+        "pubkeys": [
+          "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "installer-packaging/*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "pre-build-file-edit"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "custominstallerbuilder/html/static/installers/base/*"
+          ]
+        ]
+      },
+      {
+        "_type": "step",
+        "name": "dummy-untar-linux-base-installer",
+        "expected_command": [
+          "tar",
+          "xf",
+          "custominstallerbuilder/html/static/installers/base/seattle_linux.tgz"
+        ],
+        "pubkeys": [
+          "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5"
+        ],
+        "threshold": 1,
+        "expected_materials": [
+          [
+            "MATCH",
+            "custominstallerbuilder/html/static/installers/base/seattle_linux.tgz",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "build-base-installers"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "*"
+          ]
+        ]
+      }
+    ],
+    "inspect": [
+      {
+        "_type": "inspection",
+        "name": "untar-linux-installer",
+        "run": [
+          "tar",
+          "xf",
+          "seattle_linux.tgz"
+        ],
+        "expected_materials": [
+          [
+            "CREATE",
+            "*"
+          ]
+        ],
+        "expected_products": [
+          [
+            "CREATE",
+            "seattle/seattle_repy/vesselinfo"
+          ],
+          [
+            "MATCH",
+            "seattle/*",
+            "WITH",
+            "PRODUCTS",
+            "FROM",
+            "dummy-untar-linux-base-installer"
+          ],
+          [
+            "CREATE",
+            "*"
+          ]
+        ]
+      }
+    ],
+    "keys": {
+      "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5": {
+        "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+        "keytype": "rsa",
+        "keyval": {
+          "private": "",
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKC..."
+        }
+      }
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "85ed317c5950f8c5921bb547bdecb4e7c697c9502164d60d9c922ff384b083c5",
+      "method": "RSASSA-PSS",
+      "sig": "ceb3ce5664472dccee0ec9fdf20a281418ab6b537374659786f75718e506b016005..."
+    }
+  ]
+}
+
+```
+
+
+## Links
+
+### seattle/clone-dependencies.d66d18.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "clone-dependencies",
+    "command": [
+      "python",
+      "initialize.py"
+    ],
+    "materials": {},
+    "products": {
+      "installer-packaging/DEPENDENCIES/affix/.travis.yml": {
+        "sha256": "d0c6c6a72dcfba6b22e321783c3455c6a680aa7bacc04db8adf184630696b999"
+      },
+      "installer-packaging/DEPENDENCIES/affix/LICENSE": {
+        "sha256": "c58358858f917e4bac08df11f6c89f39743dec35aaabdd629eea6a50341206a8"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_exceptions.r2py": {
+        "sha256": "809ff340dffb0972797844fb956a53ff3d26418180553ff13ee4fa81db0a6bc3"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_repy_network_api_wrapper.r2py": {
+        "sha256": "dc1e91306e28dfb40d21ceb6de82b6cffff207c9fca36f3e2c2d613d35e3ce4c"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_stack.r2py": {
+        "sha256": "97b147a4f3cf2bda14486def2af8d06fe96208747b239ad8c36d73efceb72e7c"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_wrapper_lib.r2py": {
+        "sha256": "9f225939d3507c90a58ae8a6157f254390612d78e94c72d67ebe56375e193bfe"
+      },
+      "installer-packaging/DEPENDENCIES/affix/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/DEPENDENCIES/affix/components/baseaffix.r2py": {
+        "sha256": "8b21380dc7a25403b279c077ff9d326ea4a0a4f73f84737f0675b9452b46ad13"
+      },
+      "installer-packaging/DEPENDENCIES/affix/components/canihear.r2py": {
+        "sha256": "fb5e95a2b921160d2446e38003280a0b49b71ff83214b12c76c8db845a9bf888"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "Checking out repo from https://github.com/SeattleTestbed/nodemanage...",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+      "method": "RSASSA-PSS",
+      "sig": "367e5d1b7a2d0cefaf44d01cdc0dd55558c0adee5d4edccf1b41ade76c84d0cfdc3..."
+    }
+  ]
+}
+
+```
+
+
+### seattle/build-runnable.d66d18.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "build-runnable",
+    "command": [
+      "python",
+      "build.py"
+    ],
+    "materials": {
+      "installer-packaging/DEPENDENCIES/affix/.travis.yml": {
+        "sha256": "d0c6c6a72dcfba6b22e321783c3455c6a680aa7bacc04db8adf184630696b999"
+      },
+      "installer-packaging/DEPENDENCIES/affix/LICENSE": {
+        "sha256": "c58358858f917e4bac08df11f6c89f39743dec35aaabdd629eea6a50341206a8"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_exceptions.r2py": {
+        "sha256": "809ff340dffb0972797844fb956a53ff3d26418180553ff13ee4fa81db0a6bc3"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_repy_network_api_wrapper.r2py": {
+        "sha256": "dc1e91306e28dfb40d21ceb6de82b6cffff207c9fca36f3e2c2d613d35e3ce4c"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_stack.r2py": {
+        "sha256": "97b147a4f3cf2bda14486def2af8d06fe96208747b239ad8c36d73efceb72e7c"
+      },
+      "installer-packaging/DEPENDENCIES/affix/affix_wrapper_lib.r2py": {
+        "sha256": "9f225939d3507c90a58ae8a6157f254390612d78e94c72d67ebe56375e193bfe"
+      },
+      "installer-packaging/DEPENDENCIES/affix/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/DEPENDENCIES/affix/components/baseaffix.r2py": {
+        "sha256": "8b21380dc7a25403b279c077ff9d326ea4a0a4f73f84737f0675b9452b46ad13"
+      },
+      "installer-packaging/DEPENDENCIES/affix/components/canihear.r2py": {
+        "sha256": "fb5e95a2b921160d2446e38003280a0b49b71ff83214b12c76c8db845a9bf888"
+      },
+      "...": "..."
+    },
+    "products": {
+      "installer-packaging/RUNNABLE/LICENSE": {
+        "sha256": "95fd62575bd6de09864bce5286e3654989ef4be834e039e92f5b6b3e533069f2"
+      },
+      "installer-packaging/RUNNABLE/README.md": {
+        "sha256": "a4e3870180bae75c2f22d45c12dbf89e7056f219d440d9fde6663684ab23c9f4"
+      },
+      "installer-packaging/RUNNABLE/advertise.r2py": {
+        "sha256": "30b979fa11919eb7adbdf931788cbba28e7cc4210e172ba8ae7468a3fff6570a"
+      },
+      "installer-packaging/RUNNABLE/advertise_objects.r2py": {
+        "sha256": "f76eee0a4b595335c7894d8db26cddb4574bcaac652f5d8f3154dbad16e791e7"
+      },
+      "installer-packaging/RUNNABLE/advertisepipe.r2py": {
+        "sha256": "8ca0f7c2fca8fb481ae87bc4f0b1c0843ff05626dd9c5315593675d23c59e37b"
+      },
+      "installer-packaging/RUNNABLE/advertiseserver_v2.r2py": {
+        "sha256": "51952a3c7c025017c9ee1d53a27c96b2ba8e57d559a16682d0dbff914cc508d6"
+      },
+      "installer-packaging/RUNNABLE/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/RUNNABLE/argparse.r2py": {
+        "sha256": "a1057faa6631c8077c427a6a961899f44c7222dc00ba16bf905ba0e1401a01f9"
+      },
+      "installer-packaging/RUNNABLE/base64.r2py": {
+        "sha256": "ff0b77447dd36cb203cf03afdbd2d1aaeab8c9e8a3831c0416a04c74b0873b7d"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "Building into /home/cib/installer-packaging/RUNNABLE\nDone building!\n",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+      "method": "RSASSA-PSS",
+      "sig": "a8c1296c9aed0d7a2f8625aa3a5825e373e90a0d2c6fce65934920671390a6b45ee..."
+    }
+  ]
+}
+
+```
+
+
+### seattle/pre-build-file-edit.d66d18.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "pre-build-file-edit",
+    "command": [],
+    "materials": {
+      "installer-packaging/RUNNABLE/LICENSE": {
+        "sha256": "95fd62575bd6de09864bce5286e3654989ef4be834e039e92f5b6b3e533069f2"
+      },
+      "installer-packaging/RUNNABLE/README.md": {
+        "sha256": "a4e3870180bae75c2f22d45c12dbf89e7056f219d440d9fde6663684ab23c9f4"
+      },
+      "installer-packaging/RUNNABLE/advertise.r2py": {
+        "sha256": "30b979fa11919eb7adbdf931788cbba28e7cc4210e172ba8ae7468a3fff6570a"
+      },
+      "installer-packaging/RUNNABLE/advertise_objects.r2py": {
+        "sha256": "f76eee0a4b595335c7894d8db26cddb4574bcaac652f5d8f3154dbad16e791e7"
+      },
+      "installer-packaging/RUNNABLE/advertisepipe.r2py": {
+        "sha256": "8ca0f7c2fca8fb481ae87bc4f0b1c0843ff05626dd9c5315593675d23c59e37b"
+      },
+      "installer-packaging/RUNNABLE/advertiseserver_v2.r2py": {
+        "sha256": "51952a3c7c025017c9ee1d53a27c96b2ba8e57d559a16682d0dbff914cc508d6"
+      },
+      "installer-packaging/RUNNABLE/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/RUNNABLE/argparse.r2py": {
+        "sha256": "a1057faa6631c8077c427a6a961899f44c7222dc00ba16bf905ba0e1401a01f9"
+      },
+      "installer-packaging/RUNNABLE/base64.r2py": {
+        "sha256": "ff0b77447dd36cb203cf03afdbd2d1aaeab8c9e8a3831c0416a04c74b0873b7d"
+      },
+      "...": "..."
+    },
+    "products": {
+      "installer-packaging/RUNNABLE/LICENSE": {
+        "sha256": "95fd62575bd6de09864bce5286e3654989ef4be834e039e92f5b6b3e533069f2"
+      },
+      "installer-packaging/RUNNABLE/README.md": {
+        "sha256": "a4e3870180bae75c2f22d45c12dbf89e7056f219d440d9fde6663684ab23c9f4"
+      },
+      "installer-packaging/RUNNABLE/advertise.r2py": {
+        "sha256": "30b979fa11919eb7adbdf931788cbba28e7cc4210e172ba8ae7468a3fff6570a"
+      },
+      "installer-packaging/RUNNABLE/advertise_objects.r2py": {
+        "sha256": "f76eee0a4b595335c7894d8db26cddb4574bcaac652f5d8f3154dbad16e791e7"
+      },
+      "installer-packaging/RUNNABLE/advertisepipe.r2py": {
+        "sha256": "8ca0f7c2fca8fb481ae87bc4f0b1c0843ff05626dd9c5315593675d23c59e37b"
+      },
+      "installer-packaging/RUNNABLE/advertiseserver_v2.r2py": {
+        "sha256": "51952a3c7c025017c9ee1d53a27c96b2ba8e57d559a16682d0dbff914cc508d6"
+      },
+      "installer-packaging/RUNNABLE/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/RUNNABLE/argparse.r2py": {
+        "sha256": "a1057faa6631c8077c427a6a961899f44c7222dc00ba16bf905ba0e1401a01f9"
+      },
+      "installer-packaging/RUNNABLE/base64.r2py": {
+        "sha256": "ff0b77447dd36cb203cf03afdbd2d1aaeab8c9e8a3831c0416a04c74b0873b7d"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": null
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+      "method": "RSASSA-PSS",
+      "sig": "656cbf10cdd2475a08a0f18232f9caa040f40fa36a5c5142c30b51233a31156f8b6..."
+    }
+  ]
+}
+
+```
+
+
+### seattle/build-base-installers.d66d18.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "build-base-installers",
+    "command": [
+      "python",
+      "rebuild_base_installers.py",
+      "0.1-in-toto-in-seattle"
+    ],
+    "materials": {
+      "installer-packaging/RUNNABLE/LICENSE": {
+        "sha256": "95fd62575bd6de09864bce5286e3654989ef4be834e039e92f5b6b3e533069f2"
+      },
+      "installer-packaging/RUNNABLE/README.md": {
+        "sha256": "a4e3870180bae75c2f22d45c12dbf89e7056f219d440d9fde6663684ab23c9f4"
+      },
+      "installer-packaging/RUNNABLE/advertise.r2py": {
+        "sha256": "30b979fa11919eb7adbdf931788cbba28e7cc4210e172ba8ae7468a3fff6570a"
+      },
+      "installer-packaging/RUNNABLE/advertise_objects.r2py": {
+        "sha256": "f76eee0a4b595335c7894d8db26cddb4574bcaac652f5d8f3154dbad16e791e7"
+      },
+      "installer-packaging/RUNNABLE/advertisepipe.r2py": {
+        "sha256": "8ca0f7c2fca8fb481ae87bc4f0b1c0843ff05626dd9c5315593675d23c59e37b"
+      },
+      "installer-packaging/RUNNABLE/advertiseserver_v2.r2py": {
+        "sha256": "51952a3c7c025017c9ee1d53a27c96b2ba8e57d559a16682d0dbff914cc508d6"
+      },
+      "installer-packaging/RUNNABLE/appveyor.yml": {
+        "sha256": "8d9eab5b578723043ce354bcadc3fcb2695a39b964f68a6601ac2f911a1108ef"
+      },
+      "installer-packaging/RUNNABLE/argparse.r2py": {
+        "sha256": "a1057faa6631c8077c427a6a961899f44c7222dc00ba16bf905ba0e1401a01f9"
+      },
+      "installer-packaging/RUNNABLE/base64.r2py": {
+        "sha256": "ff0b77447dd36cb203cf03afdbd2d1aaeab8c9e8a3831c0416a04c74b0873b7d"
+      },
+      "...": "..."
+    },
+    "products": {
+      "custominstallerbuilder/html/static/installers/base/seattle_0.1-in-toto-in-seattle_android.zip": {
+        "sha256": "77d91291b1d7d1127490aebc73cb47f372dea267bc706576bbf92535a37fa0a0"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_0.1-in-toto-in-seattle_linux.tgz": {
+        "sha256": "87d1d193917b41a96e8c69b5df268a5ac044f3b892b3392a472daef8c94adae3"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_0.1-in-toto-in-seattle_mac.tgz": {
+        "sha256": "e67f9f0b95f67229b25433e09a64bb36357742420f0f7489a6f009a517670236"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_0.1-in-toto-in-seattle_win.zip": {
+        "sha256": "29f0d2e6f23996018327675cbc36eab3eb4bcb56b9001017085a7f9a4d17adae"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_android.zip": {
+        "sha256": "77d91291b1d7d1127490aebc73cb47f372dea267bc706576bbf92535a37fa0a0"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_linux.tgz": {
+        "sha256": "87d1d193917b41a96e8c69b5df268a5ac044f3b892b3392a472daef8c94adae3"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_mac.tgz": {
+        "sha256": "e67f9f0b95f67229b25433e09a64bb36357742420f0f7489a6f009a517670236"
+      },
+      "custominstallerbuilder/html/static/installers/base/seattle_win.zip": {
+        "sha256": "29f0d2e6f23996018327675cbc36eab3eb4bcb56b9001017085a7f9a4d17adae"
+      }
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "Archiving old base installers to /home/cib/custominstallerbuilder/h...",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+      "method": "RSASSA-PSS",
+      "sig": "7b592b27665d3b547aacd4c59a3871972edb4a923202728fe458ddbe49c6c20952c..."
+    }
+  ]
+}
+
+```
+
+
+### seattle/dummy-untar-linux-base-installer.d66d18.link
+``` json
+{
+  "signed": {
+    "_type": "link",
+    "name": "dummy-untar-linux-base-installer",
+    "command": [
+      "tar",
+      "xf",
+      "custominstallerbuilder/html/static/installers/base/seattle_linux.tgz"
+    ],
+    "materials": {
+      "custominstallerbuilder/html/static/installers/base/seattle_linux.tgz": {
+        "sha256": "87d1d193917b41a96e8c69b5df268a5ac044f3b892b3392a472daef8c94adae3"
+      }
+    },
+    "products": {
+      "seattle/install.sh": {
+        "sha256": "ca523d1ca5b331278fc4eb7a09c0296314b00dd7d90e47e90dee3d7572fe73ea"
+      },
+      "seattle/seattle_repy/BandwidthClient.py": {
+        "sha256": "3538c302e2412d095c15cd00b1b85f68af6b42cff0a624aa53dc560cc0341770"
+      },
+      "seattle/seattle_repy/BandwidthServer.py": {
+        "sha256": "3369ef9eaf7e7ce02c304c55699738c0a6a6c21dcc1e053b7e10875f9d5dc4ff"
+      },
+      "seattle/seattle_repy/LICENSE": {
+        "sha256": "95fd62575bd6de09864bce5286e3654989ef4be834e039e92f5b6b3e533069f2"
+      },
+      "seattle/seattle_repy/LICENSE.txt": {
+        "sha256": "c349ed2c887cc4798462516fb3fbeea19e4f8dcf81444983006ef7e15d876de9"
+      },
+      "seattle/seattle_repy/Linux_resources.py": {
+        "sha256": "b2520913a0a27ae6c716190fa3f4c23a3b02fc174da99b816c90f20acf57dfb6"
+      },
+      "seattle/seattle_repy/Mac_BSD_resources.py": {
+        "sha256": "a56e6e1725f22d4b055b9a9bd5e7e6a349a1a18b180992c42563936d4c7f9e3f"
+      },
+      "seattle/seattle_repy/README.txt": {
+        "sha256": "6a72741a949dba40179472a93c7b458f7cfd38f2261baf131712b9139ebaa921"
+      },
+      "seattle/seattle_repy/Win_WinCE_resources.py": {
+        "sha256": "137856aac0ca9b6c1116ffb19c39cc355ce4734afe97911a39e1664698ea16af"
+      },
+      "...": "..."
+    },
+    "byproducts": {
+      "return_value": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    "environment": {}
+  },
+  "signatures": [
+    {
+      "keyid": "d66d18e768284e519ed2d0774376faf4859cb6529bf6e392621b8d42752206d5",
+      "method": "RSASSA-PSS",
+      "sig": "aa05b3773b3cad3a1d70b7ae43fd37f168a59c7e65b24affe81dae0a290981e10e0..."
+    }
+  ]
+}
+
+```
+
+


### PR DESCRIPTION
Transfer metadata examples from old in-toto website repo for
debian, pph and seattle projects, adapting front matter
(jekyll->hugo) and removing redundant title and empty readme
section.

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>