### PR TITLE
Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,10 @@ command = "make preview-build"
 
 [context.branch-deploy]
 command = "make preview-build"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com use.fontawesome.com"


### PR DESCRIPTION
This PR adds the headers the Badge App looks for in the project URL and version control URL.

I was able to test it works here: https://securityheaders.com/?q=https%3A%2F%2Fmystifying-heisenberg-ea1c42.netlify.app%2F&followRedirects=on for https://mystifying-heisenberg-ea1c42.netlify.app/ which is my deploy of this branch.