### PR TITLE
Fix latest spec link

### DIFF
--- a/content/in-toto.md
+++ b/content/in-toto.md
@@ -10,4 +10,4 @@ Although many frameworks exist to ensure security in the "last mile" (e.g., soft
 
 in-toto is designed to ensure the integrity of a software product from initiation to end-user installation. It does so by making it transparent to the user what steps were performed, by whom and in what order. As a result, with some guidance from the group creating the software, in-toto allows the user to verify if a step in the supply chain was intended to be performed, and if the step was performed by the right actor.
 
-You can read more about in-toto's internals in our [latest](https://github.com/in-toto/docs/raw/master/in-toto-spec.pdf) or [stable](https://github.com/in-toto/docs/blob/v0.9/in-toto-spec.pdf) specification.
+You can read more about in-toto's internals in our [latest](https://github.com/in-toto/docs/blob/master/in-toto-spec.md) or [stable](https://github.com/in-toto/docs/blob/v0.9/in-toto-spec.pdf) specification.

--- a/content/in-toto.md
+++ b/content/in-toto.md
@@ -10,4 +10,4 @@ Although many frameworks exist to ensure security in the "last mile" (e.g., soft
 
 in-toto is designed to ensure the integrity of a software product from initiation to end-user installation. It does so by making it transparent to the user what steps were performed, by whom and in what order. As a result, with some guidance from the group creating the software, in-toto allows the user to verify if a step in the supply chain was intended to be performed, and if the step was performed by the right actor.
 
-You can read more about in-toto's internals in our [latest](https://github.com/in-toto/docs/blob/master/in-toto-spec.md) or [stable](https://github.com/in-toto/docs/blob/v0.9/in-toto-spec.pdf) specification.
+You can read more about in-toto's internals in our [latest](https://github.com/in-toto/docs/blob/master/in-toto-spec.md) or [stable](https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.pdf) specification.

--- a/data/news.yaml
+++ b/data/news.yaml
@@ -1,3 +1,6 @@
+- date: 2023-06-05
+  text: |
+    in-toto's specification reached v1.0! Find it [here](https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.md).
 - date: 2022-03-10
   text: |
     in-toto has moved from the Cloud Native Computing Foundation (CNCF) Sandbox to the Incubator! Read the full announcement [here](https://www.cncf.io/blog/2022/03/10/supply-chain-security-project-in-toto-moves-to-the-cncf-incubator/).

--- a/data/specs.yaml
+++ b/data/specs.yaml
@@ -1,6 +1,11 @@
-- version: Stable (v0.9)
-  url: https://github.com/in-toto/docs/blob/v0.9/in-toto-spec.md
-  description: This is a thoroughly-reviewed version of the specification (and probably what you're looking for)
-- version: Latest
+- version: in-toto Stable (v1.0)
+  url: https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.md
+  description: This is a thoroughly-reviewed version of the specification (and probably what you're looking for).
+- version: in-toto Latest
   url: https://github.com/in-toto/docs/blob/master/in-toto-spec.md
-  description: If you want to see what are the latest changes and possible features, click this.
+  description: If you want to see the latest changes and possible features, click this.
+- version: in-toto Attestation Framework Stable (v1.0)
+  url: https://github.com/in-toto/attestation/tree/v1.0/
+  description: The in-toto Attestation Framework is developed independently of the in-toto specification. A future version of the in-toto specification will incorporate this framework as the mechanism to express software supply chain claims.
+- version: in-toto Attestation Framework Latest
+  description: If you want to see the latest changes to the in-toto Attestation Framework, click this.


### PR DESCRIPTION
Latest spec link in website: https://in-toto.io/in-toto/ is 404, maybe https://github.com/in-toto/docs/blob/master/in-toto-spec.md is correct.