### PR TITLE
Add redirect for release predicate

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -11,6 +11,9 @@ SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predic
 # Below version numbers are in the spec at the v1.0 tag
 Statement/v1      https://github.com/in-toto/attestation/blob/v1.0/spec/v1.0/statement.md
 
+# Below version numbers are in the spec at the v1.0.2 tag
+Release/v1        https://github.com/in-toto/attestation/blob/v1.0.2/spec/predicates/release.md
+
 # Bonus: v0.1.0 <-> v0.1
 Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope 
 Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate 

--- a/public/_redirects
+++ b/public/_redirects
@@ -11,8 +11,8 @@ SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predic
 # Below version numbers are in the spec at the v1.0 tag
 Statement/v1      https://github.com/in-toto/attestation/blob/v1.0/spec/v1.0/statement.md
 
-# Below version numbers are in the spec at the v1.0.2 tag
-Release/v1        https://github.com/in-toto/attestation/blob/v1.0.2/spec/predicates/release.md
+# Below version numbers use main branch
+Release/v0.1      https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md
 
 # Bonus: v0.1.0 <-> v0.1
 Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope 


### PR DESCRIPTION
As requested in https://github.com/in-toto/attestation/pull/319 and detailed in https://github.com/in-toto/attestation/pull/320.

I'm not exactly sure how this should work. I'm assuming that after https://github.com/in-toto/attestation/pull/319 lands, there would be a v1.0.2 release cut of https://github.com/in-toto/attestation/, and then this PR should land?

Definitely open to feedback here.