### PR TITLE
Add missing predicate spec redirects, update Statement v1 redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -21,19 +21,19 @@ Statement/v1      https://github.com/in-toto/attestation/blob/main/spec/v1/state
 
 # Below are vetted Attestation Framework predicates (versioned independently)
 attestation/link https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
-attestation/link/v0.3 https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
+attestation/link/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
 
 attestation/release https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
-attestation/release/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
+attestation/release/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
 
 attestation/runtime-trace https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
-attestation/runtime-trace/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
+attestation/runtime-trace/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
 
 attestation/scai/attribute-report/ https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
-attestation/scai/attribute-report/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/scai/attribute-report/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
 
 attestation/test-result https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
-attestation/test-result/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
+attestation/test-result/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
 
 attestation/vulns https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
-attestation/vulns/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
+attestation/vulns/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md

--- a/public/_redirects
+++ b/public/_redirects
@@ -29,11 +29,11 @@ attestation/release/v0.1 https://github.com/in-toto/attestation/tree/main/spec/p
 attestation/runtime-trace https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
 attestation/runtime-trace/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
 
-attestation/scai https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
-attestation/scai/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/scai/attribute-report/ https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/scai/attribute-report/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
 
 attestation/test-result https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
 attestation/test-result/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
 
-attestation/vuln https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
-attestation/vuln/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
+attestation/vulns https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
+attestation/vulns/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md

--- a/public/_redirects
+++ b/public/_redirects
@@ -21,8 +21,17 @@ Provenance/v0.1   https://github.com/in-toto/attestation/tree/v0.1.0/spec/predic
 Statement/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
 
 # Below are vetted Attestation Framework predicates (versioned independently)
+attestation/link https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
 attestation/link/v0.3 https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
+
+attestation/runtime-trace https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
 attestation/runtime-trace/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
+
+attestation/scai https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
 attestation/scai/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+
+attestation/test-result https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
 attestation/test-result/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
+
+attestation/vuln https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
 attestation/vuln/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md

--- a/public/_redirects
+++ b/public/_redirects
@@ -8,8 +8,8 @@ Link/v1.0.0       https://github.com/in-toto/attestation/tree/v0.1.0/spec/predic
 Provenance/v0.1.0 https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
 SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/spdx.md
 
-# Below version numbers are in the spec at the v1.0 tag
-Statement/v1      https://github.com/in-toto/attestation/blob/v1.0/spec/v1.0/statement.md
+# Below version numbers are in the spec at the v1.x tag
+Statement/v1      https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md
 
 # Below version numbers use main branch
 Release/v0.1      https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md
@@ -19,3 +19,10 @@ Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelo
 Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate 
 Provenance/v0.1   https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
 Statement/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
+
+# Below are vetted Attestation Framework predicates (versioned independently)
+attestation/link/v0.3 https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
+attestation/runtime-trace/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
+attestation/scai/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/test-result/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
+attestation/vuln/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md

--- a/public/_redirects
+++ b/public/_redirects
@@ -8,21 +8,23 @@ Link/v1.0.0       https://github.com/in-toto/attestation/tree/v0.1.0/spec/predic
 Provenance/v0.1.0 https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
 SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/spdx.md
 
-# Below version numbers are in the spec at the v1.x tag
-Statement/v1      https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md
-
-# Below version numbers use main branch
-Release/v0.1      https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md
-
 # Bonus: v0.1.0 <-> v0.1
 Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope 
 Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate 
 Provenance/v0.1   https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
 Statement/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
 
+# Below version numbers use main branch
+
+# Below version numbers are in the spec at the v1.x tag
+Statement/v1      https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md
+
 # Below are vetted Attestation Framework predicates (versioned independently)
 attestation/link https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
 attestation/link/v0.3 https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
+
+attestation/release https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
+attestation/release/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
 
 attestation/runtime-trace https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
 attestation/runtime-trace/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md


### PR DESCRIPTION
This PR adds redirects for all vetted [`predicateType` URIs](https://github.com/in-toto/attestation/blob/main/spec/v1/predicate.md) (latest versions as of today), and updates the `Statement/v1` redirect to point to the `v1` directory containing the latest Statement spec, rather than a git tag.

Fixes https://github.com/in-toto/attestation/issues/321 
Fixes https://github.com/in-toto/attestation/issues/346