### PR TITLE
[docsy][blog] Normalize path and add alias

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -38,7 +38,7 @@
 
     a {
       color: white;
-      .external-link:after {
+      &.external-link:after {
         display: none;
       }
     }

--- a/content/en/blog/2023/security-audit.md
+++ b/content/en/blog/2023/security-audit.md
@@ -1,8 +1,9 @@
 ---
 title: Security Audit '23
 date: 2023-05-11
-author:
-  'Aditya Sirish, [NYU Secure Systems Lab](https://ssl.engineering.nyu.edu)'
+aliases: [/security-audit-23]
+author: >
+  Aditya Sirish, [NYU Secure Systems Lab](https://ssl.engineering.nyu.edu)
 ---
 
 We are excited to announce completion of a source code audit of the in-toto


### PR DESCRIPTION
- Renames solo blog entry, dropping the 23 suffix since it's inside a 2023 folder.
- SCSS fix