### PR TITLE
[docsy] Rework news page

### DIFF
--- a/assets/scss/_news.scss
+++ b/assets/scss/_news.scss
@@ -1,23 +1,13 @@
 .in-toto-news {
   .in-toto-columns {
-    display: flex;
-    align-items: flex-start;
     margin-bottom: 10px;
   }
 
   .in-toto-column {
-    display: block;
     padding-left: 0.75rem;
   }
 
-  .is-2 {
-    flex: 0 0 16.67%; /* Equivalent to 2 out of 12 columns */
+  .news-date {
     font-weight: bold;
-    color: var(--bs-tertiary-color);
-  }
-
-  .in-toto-column-content {
-    flex: 1;
-    margin-left: 20px;
   }
 }

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -3,7 +3,14 @@ title: News
 menu:
   main: { weight: 80 }
 outputs: [HTML, RSS]
-type: docs
 ---
 
+{{% blocks/cover title="News" height="auto" %}}
+
+{{% /blocks/cover %}}
+
+{{% blocks/section color="white" %}}
+
 {{< news >}}
+
+{{% /blocks/section %}}

--- a/data/news.yaml
+++ b/data/news.yaml
@@ -1,6 +1,6 @@
 - date: 2023-06-05
   text: |
-    in-toto's specification reached v1.0! Find it [here](https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.md).
+    in-toto's specification [reaches v1.0](https://github.com/in-toto/docs/blob/v1.0/in-toto-spec.md)!
 - date: 2022-03-10
   text: |
     in-toto has moved from the Cloud Native Computing Foundation (CNCF) Sandbox to the Incubator! Read the full announcement [here](https://www.cncf.io/blog/2022/03/10/supply-chain-security-project-in-toto-moves-to-the-cncf-incubator/).

--- a/layouts/shortcodes/news.html
+++ b/layouts/shortcodes/news.html
@@ -1,16 +1,12 @@
-{{ $news := site.Data.news }}
+{{ $news := site.Data.news -}}
+
 <div class="in-toto-news">
   {{ range $news }}
-  {{ $date := dateFormat "January 2, 2006" .date }}
+  {{ $date := dateFormat "January 2, 2006" .date -}}
   <div class="in-toto-columns in-toto-content is-medium">
-    <div class="column is-2">
-      <strong>
-        {{ $date }}
-      </strong>
-    </div>
-
+    <div class="news-date">{{ $date }}</div>
     <div class="in-toto-column">
-      {{ .text | markdownify }}
+      {{- .text | markdownify -}}
     </div>
   </div>
   {{ end }}


### PR DESCRIPTION
Gives the News page a similar look-and-feel to the original site, with a hero image, rather than a docs-section look.

**Preview**: https://deploy-preview-70--in-toto.netlify.app/news/