### PR TITLE
Helm charts redirect

### DIFF
--- a/content/helm-charts.md
+++ b/content/helm-charts.md
@@ -1,0 +1,4 @@
+---
+type: redirect
+target: https://in-toto.github.io/helm-charts
+---

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,1 @@
+{{- template "_internal/alias.html" (dict "Permalink" .Params.target) -}}


### PR DESCRIPTION
We need to host our helm-charts repository on github pages (to decouple updating the repository) for that project. Let's add a redirect on netlify to that github repo for ease of discovery  as well.