### PR TITLE
[docsy][CI] check-format workflow: drop unnecessary setup

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -19,16 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create NPM cache-hash input file
-        run: |
-          mkdir -p tmp
-          jq '{devDependencies, engines, gitHubActionCacheKey}' package.json > tmp/package-ci.json
-
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: npm
-          cache-dependency-path: tmp/package-ci.json
+          cache-dependency-path: package.json
 
       - name: Check file format
-        run: npm run check:format --ignore-scripts
+        run: |
+          npm run __install:prettier
+          npm run check:format

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "docsy-user-guide",
   "scripts": {
+    "__install:prettier": "npm install prettier@$(npm pkg get devDependencies.prettier | tr -d '^\"') --no-save",
     "_build": "npm run _hugo-dev --",
-    "_check:format": "npx prettier@$(npm pkg get devDependencies.prettier | tr -d '^\"') --check .",
+    "_check:format": "npx prettier --check .",
     "_check:links": "make check-links",
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
     "_filename-error": "echo 'ERROR: the following files violate naming conventions; fix using: `npm run fix:filenames`'; echo; npm run -s _ls-bad-filenames; exit 1",


### PR DESCRIPTION
- Drops unnecessary code from check-format workflow, now that the `npx prettier` command in the NMP scripts fetches the proper Prettier version