### PR TITLE
[CI/infra] Generate redirects for aliases

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,5 +1,8 @@
 ---
 title: in-toto
+outputs:
+  - HTML
+  - REDIRECTS # Include this `content/en` ONLY
 description: A framework to secure the integrity of software supply chains
 ---
 

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -2,6 +2,7 @@
 title: About in-toto
 linkTitle: About
 menu: { main: { weight: 10 } }
+aliases: [/in-toto]
 ---
 
 {{% blocks/cover title="About in-toto" height="auto" %}}

--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -1,6 +1,7 @@
 ---
 title: Frequently asked questions
 linkTitle: FAQ
+aliases: [/faq]
 weight: 900
 ---
 

--- a/content/en/docs/specs.md
+++ b/content/en/docs/specs.md
@@ -1,6 +1,7 @@
 ---
 title: Specifications
 linkTitle: Specs
+aliases: [/specs]
 weight: 70
 ---
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,7 +1,7 @@
 baseURL: https://in-toto.io
 title: in-toto
 
-# cSpell:ignore Catmull Libera noopener
+# cSpell:ignore AFRL Catmull DARPA docsy Libera noopener
 
 disableKinds: [taxonomy]
 theme: [docsy]
@@ -13,9 +13,16 @@ enableGitInfo: true
 
 disableAliases: true # We do redirects via Netlify's _redirects file
 
+mediaTypes:
+  text/netlify: {}
+
+outputFormats:
+  REDIRECTS:
+    mediaType: text/netlify
+    baseName: _redirects
+    notAlternative: true
+
 outputs:
-  home: [HTML]
-  page: [HTML]
   section: [HTML]
 
 imaging:

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,6 +1,9 @@
+# Netlify redirects. See https://www.netlify.com/docs/redirects/
+{{/* cSpell:ignore cond wordmark */ -}}
+
 # No versions mentioned in the spec so assume v0.1
-Envelope/v0.1     https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope 
-Predicate/v0.1    https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate 
+Envelope/v0.1     https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope
+Predicate/v0.1    https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate
 
 # Below version numbers are in the spec at the v0.1.0 tag.
 Statement/v0.1    https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
@@ -9,8 +12,8 @@ Provenance/v0.1.0 https://github.com/in-toto/attestation/tree/v0.1.0/spec/predic
 SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/spdx.md
 
 # Bonus: v0.1.0 <-> v0.1
-Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope 
-Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate 
+Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope
+Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate
 Provenance/v0.1   https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
 Statement/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
 
@@ -37,3 +40,28 @@ attestation/test-result/v* https://github.com/in-toto/attestation/tree/main/spec
 
 attestation/vulns https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
 attestation/vulns/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
+
+{{ range $p := .Site.Pages -}}
+
+{{ range $p.Aliases -}}
+{{ $alias := cond (strings.HasPrefix . "/")
+    .
+    (partial "relative-redirects-alias" (dict "alias" . "p" $p.Parent)) -}}
+{{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
+{{ end -}}
+
+{{ end }}{{/* range $p */ -}}
+
+{{- define "partials/relative-redirects-alias" -}}
+  {{ $result := "" }}
+  {{ if strings.HasPrefix .alias "../" }}
+    {{ $result = (partial "relative-redirects-alias"
+          (dict
+            "alias" (strings.TrimPrefix "../" .alias)
+            "p" .p.Parent ))
+    }}
+  {{ else }}
+    {{ $result = path.Join .p.RelPermalink .alias }}
+  {{ end }}
+  {{ return $result }}
+{{ end }}


### PR DESCRIPTION
- Fixes #62
- **Preview**: https://deploy-preview-88--in-toto.netlify.app/
- **Redirect rule tests** (selected):
  - https://deploy-preview-88--in-toto.netlify.app/contact/ --> Community
  - https://deploy-preview-88--in-toto.netlify.app/in-toto/ --> About
  - https://deploy-preview-88--in-toto.netlify.app/specs/ --> `/docs/specs`
  - https://deploy-preview-88--in-toto.netlify.app/security-audit-23/ --> Blog post
  - https://deploy-preview-88--in-toto.netlify.app/examples/seattle/ -->  `/docs/examples/seattle/`
  - https://deploy-preview-88--in-toto.netlify.app/faq/ -->  `/docs/faq/`
