### PR TITLE
Add link on community page to LFX Calendar

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -108,6 +108,10 @@ params:
         url: https://web.libera.chat/#in-toto
         icon: fa-solid fa-comments
         desc: Chat with us on Libera.
+      - name: Meetings
+        url: https://zoom-lfx.platform.linuxfoundation.org/meetings/intoto
+        icon: fa-solid fa-calendar
+        desc: Join our monthly community meetings.
     developer:
       - name: Reporting issues
         url: /docs/security


### PR DESCRIPTION
This will render as a link to find our community calendar.