### PR TITLE
Update redirects to use blob URLs and add helm-charts

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -7,46 +7,48 @@ Predicate/v0.1    https://github.com/in-toto/attestation/tree/v0.1.0/spec#predic
 
 # Below version numbers are in the spec at the v0.1.0 tag.
 Statement/v0.1    https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
-Link/v1.0.0       https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/link.md
-Provenance/v0.1.0 https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
-SPDX/v1.0.0       https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/spdx.md
+Link/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/link.md
+Provenance/v0.1.0 https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
+SPDX/v1.0.0       https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/spdx.md
 
 # Bonus: v0.1.0 <-> v0.1
 Envelope/v0.1.0   https://github.com/in-toto/attestation/tree/v0.1.0/spec#envelope
 Predicate/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#predicate
-Provenance/v0.1   https://github.com/in-toto/attestation/tree/v0.1.0/spec/predicates/provenance.md
+Provenance/v0.1   https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
 Statement/v0.1.0  https://github.com/in-toto/attestation/tree/v0.1.0/spec#statement
 
 # Below version numbers use main branch
 
 # Below version numbers are in the spec at the v1.x tag
-Statement/v1      https://github.com/in-toto/attestation/tree/main/spec/v1/statement.md
+Statement/v1      https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md
 
 # Below are vetted Attestation Framework predicates (versioned independently)
-attestation/link https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
-attestation/link/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/link.md
+attestation/link https://github.com/in-toto/attestation/blob/main/spec/predicates/link.md
+attestation/link/v* https://github.com/in-toto/attestation/blob/main/spec/predicates/link.md
 
-attestation/release https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
-attestation/release/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/release.md
+attestation/release https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md
+attestation/release/v* https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md
 
-attestation/runtime-trace https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
-attestation/runtime-trace/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/runtime-trace.md
+attestation/runtime-trace https://github.com/in-toto/attestation/blob/main/spec/predicates/runtime-trace.md
+attestation/runtime-trace/v* https://github.com/in-toto/attestation/blob/main/spec/predicates/runtime-trace.md
 
-attestation/scai/attribute-report/ https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
-attestation/scai/attribute-report/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/scai/attribute-report/ https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md
+attestation/scai/attribute-report/v* https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md
 
-attestation/test-result https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
-attestation/test-result/v* https://github.com/in-toto/attestation/tree/main/spec/predicates/test-result.md
+attestation/test-result https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
+attestation/test-result/v* https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 
-attestation/vulns/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/vuln.md
-attestation/vulns/v0.2 https://github.com/in-toto/attestation/tree/main/spec/predicates/vulns_02.md
-attestation/vulns https://github.com/in-toto/attestation/tree/main/spec/predicates/vulns_02.md
+attestation/vulns/v0.1 https://github.com/in-toto/attestation/blob/main/spec/predicates/vuln.md
+attestation/vulns/v0.2 https://github.com/in-toto/attestation/blob/main/spec/predicates/vulns_02.md
+attestation/vulns https://github.com/in-toto/attestation/blob/main/spec/predicates/vulns_02.md
 
-attestation/reference/v0.1 https://github.com/in-toto/attestation/tree/main/spec/predicates/reference.md
-attestation/reference https://github.com/in-toto/attestation/tree/main/spec/predicates/reference.md
+attestation/reference/v0.1 https://github.com/in-toto/attestation/blob/main/spec/predicates/reference.md
+attestation/reference https://github.com/in-toto/attestation/blob/main/spec/predicates/reference.md
 
-attestation/scai/v0.3 https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
-attestation/scai https://github.com/in-toto/attestation/tree/main/spec/predicates/scai.md
+attestation/scai/v0.3 https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md
+attestation/scai https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md
+
+/helm-charts https://in-toto.github.io/helm-charts
 
 {{ range $p := .Site.Pages -}}
 
@@ -71,4 +73,4 @@ attestation/scai https://github.com/in-toto/attestation/tree/main/spec/predicate
     {{ $result = path.Join .p.RelPermalink .alias }}
   {{ end }}
   {{ return $result }}
-{{ end }}
+{{ end -}}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "_check:format": "npx prettier --check .",
     "_check:links": "make check-links",
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
+    "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit -m \"Site at $HASH\"",
     "_filename-error": "echo 'ERROR: the following files violate naming conventions; fix using: `npm run fix:filenames`'; echo; npm run -s _ls-bad-filenames; exit 1",
     "_filenames-to-kebab-case": "find assets content -name '*_*' ! -name '[_.]*' -exec sh -c 'mv \"$1\" \"${1//_/-}\"' _ {} \\;",
     "_get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
@@ -34,8 +35,7 @@
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve": "npm run _serve",
     "test": "npm run seq -- check:filenames check:format check:links",
-    "update:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
-    "update:pkgs": "npx npm-check-updates -u"
+    "update:packages": "npx npm-check-updates -u"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
@@ -58,5 +58,5 @@
     "proseWrap": "always",
     "singleQuote": true
   },
-  "spelling": "cSpell:ignore docsy hugo HTMLTEST pkgs netlify precheck postbuild -"
+  "spelling": "cSpell:ignore docsy hugo htmltest netlify precheck postbuild -"
 }


### PR DESCRIPTION
- Fixes #100
- Implements heml-chart redirect via `index.redirects`
  - Closes #81 by superseding it
- **Preview**: https://deploy-preview-101--in-toto.netlify.app/
- **Redirect rule tests** (selected):
  - https://deploy-preview-101--in-toto.netlify.app/helm-charts
  - https://deploy-preview-101--in-toto.netlify.app/SPDX/v1.0.0
